### PR TITLE
Prototype of memory caching (attempt #1)

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1065,7 +1065,7 @@ let string_to_char_list s =
 
 let make_conf from_addr request script_name env =
   if !allowed_tags_file <> "" && not (Sys.file_exists !allowed_tags_file) then (
-    let str = 
+    let str =
      Printf.sprintf
        "Requested allowed_tags file (%s) absent" !allowed_tags_file
     in
@@ -1175,7 +1175,7 @@ let make_conf from_addr request script_name env =
     with Not_found -> false
   in
   let wizard_just_friend = if manitou then false else wizard_just_friend in
-  let private_years = 
+  let private_years =
     try int_of_string (List.assoc "private_years" base_env) with
     Not_found | Failure _ -> 150
   in
@@ -1414,7 +1414,7 @@ let log_and_robot_check conf auth from request script_name contents =
         end;
         log tm conf from auth request script_name contents
       end
-  
+
 let conf_and_connection =
   let slow_query_threshold =
     match Sys.getenv_opt "GWD_SLOW_QUERY_THRESHOLD" with
@@ -2032,6 +2032,10 @@ let main () =
     ; ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit)." )
     ; ("-daemon", Arg.Set daemon, " Unix daemon mode.")
 #endif
+    ; ("-cache-in-memory", Arg.String (fun s ->
+        let _db : Gwdb_driver.base = Gwdb.open_base ~keep_in_memory:true s in
+        ()
+      ), "<DATABASE> Preload this database in memory")
     ]
   in
   let speclist = List.sort compare speclist in

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -573,8 +573,8 @@ let treat_request =
           w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_inv
         | "KILL_ANC" ->
           w_wizard @@ w_lock @@ w_base @@ MergeIndDisplay.print_kill_ancestors
-        | "L" -> w_base @@ fun conf base -> Perso.interp_templ "list" conf base 
-              (Gwdb.empty_person base Gwdb.dummy_iper) 
+        | "L" -> w_base @@ fun conf base -> Perso.interp_templ "list" conf base
+              (Gwdb.empty_person base Gwdb.dummy_iper)
         | "LB" when conf.wizard || conf.friend ->
           w_base @@ BirthDeathDisplay.print_birth
         | "LD" when conf.wizard || conf.friend ->
@@ -815,7 +815,7 @@ let treat_request =
             (conf.command :> string) base_name
             (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
     in
-    Output.print_sstring conf 
+    Output.print_sstring conf
       (Printf.sprintf {|
         <form class="form-inline" method="post" action="%s">
           <div class="input-group mt-1">

--- a/lib/gwdb-legacy/btree2.ml
+++ b/lib/gwdb-legacy/btree2.ml
@@ -1,0 +1,93 @@
+(* This code is directly copied from OCaml stdlib (Map module)
+   with t*)
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('key, 'a) t =
+  | Empty
+  | Node of { l : ('key, 'a) t; v : 'key; d : 'a; r : ('key, 'a) t; h : int }
+
+let height = function Empty -> 0 | Node { h } -> h
+
+let create l x d r =
+  let hl = height l and hr = height r in
+  Node { l; v = x; d; r; h = (if hl >= hr then hl + 1 else hr + 1) }
+
+let bal l x d r =
+  let hl = match l with Empty -> 0 | Node { h } -> h in
+  let hr = match r with Empty -> 0 | Node { h } -> h in
+  if hl > hr + 2 then
+    match l with
+    | Empty -> invalid_arg "Map.bal"
+    | Node { l = ll; v = lv; d = ld; r = lr } -> (
+        if height ll >= height lr then create ll lv ld (create lr x d r)
+        else
+          match lr with
+          | Empty -> invalid_arg "Map.bal"
+          | Node { l = lrl; v = lrv; d = lrd; r = lrr } ->
+              create (create ll lv ld lrl) lrv lrd (create lrr x d r))
+  else if hr > hl + 2 then
+    match r with
+    | Empty -> invalid_arg "Map.bal"
+    | Node { l = rl; v = rv; d = rd; r = rr } -> (
+        if height rr >= height rl then create (create l x d rl) rv rd rr
+        else
+          match rl with
+          | Empty -> invalid_arg "Map.bal"
+          | Node { l = rll; v = rlv; d = rld; r = rlr } ->
+              create (create l x d rll) rlv rld (create rlr rv rd rr))
+  else Node { l; v = x; d; r; h = (if hl >= hr then hl + 1 else hr + 1) }
+
+let rec add compare x data = function
+  | Empty -> Node { l = Empty; v = x; d = data; r = Empty; h = 1 }
+  | Node { l; v; d; r; h } as m ->
+      let c = compare x v in
+      if c = 0 then if d == data then m else Node { l; v = x; d = data; r; h }
+      else if c < 0 then
+        let ll = add compare x data l in
+        if l == ll then m else bal ll v d r
+      else
+        let rr = add compare x data r in
+        if r == rr then m else bal l v d rr
+
+let rec find compare x = function
+  | Empty -> raise Not_found
+  | Node { l; v; d; r } ->
+      let c = compare x v in
+      if c = 0 then d else find compare x (if c < 0 then l else r)
+
+let rec mem compare x = function
+  | Empty -> false
+  | Node { l; v; r } ->
+      let c = compare x v in
+      c = 0 || mem compare x (if c < 0 then l else r)
+
+(* Added for GeneWeb *)
+
+let rec key_after f_compare = function
+  | Empty -> raise Not_found
+  | Node { l; v; r; _ } ->
+      let c = f_compare v in
+      if c < 0 then try key_after f_compare l with Not_found -> v
+      else if c > 0 then key_after f_compare r
+      else v
+
+let rec next compare x = function
+  | Empty -> raise Not_found
+  | Node { l; v; r; _ } ->
+      let c = compare x v in
+      if c < 0 then try next compare x l with Not_found -> v
+      else next compare x r

--- a/lib/gwdb-legacy/btree2.mli
+++ b/lib/gwdb-legacy/btree2.mli
@@ -1,0 +1,20 @@
+(** Same as {!Stdlib.Map.S.key} *)
+
+type ('key, +'a) t
+(** Same as {!Stdlib.Map.S.t} *)
+
+val mem : ('key -> 'key -> int) -> 'key -> ('key, 'a) t -> bool
+(** Same as {!Stdlib.Map.S.mem} *)
+
+val add : ('key -> 'key -> int) -> 'key -> 'a -> ('key, 'a) t -> ('key, 'a) t
+(** Same as {!Stdlib.Map.S.add} *)
+
+val find : ('key -> 'key -> int) -> 'key -> ('key, 'a) t -> 'a
+(** Same as {!Stdlib.Map.S.find} *)
+
+val key_after : ('key -> int) -> ('key, 'a) t -> 'key
+(** [key_after f_compare m] browse map [m] to find the 'key [k] which
+        gives [f_compare k = 0]. Raise [Not_found] if such 'key doesn't exists. *)
+
+val next : ('key -> 'key -> int) -> 'key -> ('key, 'a) t -> 'key
+(** [next k bt] returns the smallest 'key that is bigger then [k] inside [bt]. *)

--- a/lib/gwdb-legacy/database.mli
+++ b/lib/gwdb-legacy/database.mli
@@ -1,8 +1,13 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-val opendb : string -> Dbdisk.dsk_base
-(** Initialise [dsk_base] from the database situated in the specified directory.
-    Initialises both data and functionallity part. *)
+val opendb : ?keep_in_memory:bool -> string -> Dbdisk.dsk_base
+(** Initialise [dsk_base] from the database situated in the specified
+   directory.  Initialises both data and functionallity part.
+
+    If ~keep_in_memory:true, then the database will be loaded in memory,
+   and kept in a cache. All next uses of opendb on the same database
+   will use the memory-loaded database.
+*)
 
 val make :
   string ->

--- a/lib/gwdb-legacy/dune
+++ b/lib/gwdb-legacy/dune
@@ -4,4 +4,4 @@
  (implements geneweb.gwdb_driver)
  (libraries geneweb.def geneweb.util re unix)
  (modules_without_implementation dbdisk)
- (modules btree database dbdisk dutil gwdb_driver gwdb_gc iovalue outbase))
+ (modules btree btree2 database dbdisk dutil gwdb_driver gwdb_gc iovalue outbase))

--- a/lib/gwdb-legacy/dune
+++ b/lib/gwdb-legacy/dune
@@ -2,6 +2,6 @@
  (name gwdb_legacy)
  (public_name geneweb.gwdb-legacy)
  (implements geneweb.gwdb_driver)
- (libraries geneweb.def geneweb.util re unix)
+ (libraries geneweb.def geneweb.util re unix ancient)
  (modules_without_implementation dbdisk)
  (modules btree btree2 database dbdisk dutil gwdb_driver gwdb_gc iovalue outbase))

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -30,7 +30,9 @@ let spi_next (spi : string_person_index) istr = spi.next istr
 
 type base = dsk_base
 
-let open_base bname : base = Database.opendb bname
+let open_base ?keep_in_memory bname : base =
+  Database.opendb ?keep_in_memory bname
+
 let sou base i = base.data.strings.get i
 let bname base = Filename.(remove_extension @@ basename base.data.bdir)
 let nb_of_persons base = base.data.persons.len

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -52,7 +52,7 @@ type string_person_index
 type base
 (** The database representation. *)
 
-val open_base : string -> base
+val open_base : ?keep_in_memory:bool -> string -> base
 (** Open database associated with (likely situated in) the specified directory. *)
 
 val close_base : base -> unit


### PR DESCRIPTION
* Add an argument `?keep_in_memory:bool` to `opendb` to keep the database in memory (let's hope it is never muted by operations !)
* Add a new option `--cache-in-memory DATABASE` to specify a database that should be preloaded by `gwd` and kept in memory 
* Modify `database.ml` to create a single cache structure for all separate caches (work-in-progress...)
